### PR TITLE
Enable VS2022 support

### DIFF
--- a/src/EvoCodeGen/EvoCodeGen.Core/EvoCodeGen.Core.csproj
+++ b/src/EvoCodeGen/EvoCodeGen.Core/EvoCodeGen.Core.csproj
@@ -33,11 +33,11 @@
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TextTemplating.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.TextTemplating.15.0.dll</HintPath>
+      <HintPath>$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TextTemplating.15.0.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\PublicAssemblies\Microsoft.VisualStudio.TextTemplating.Interfaces.10.0.dll</HintPath>
+      <HintPath>$(VSToolsPath)\PublicAssemblies\Microsoft.VisualStudio.TextTemplating.Interfaces.10.0.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/EvoCodeGen/EvoCodeGen/source.extension.vsixmanifest
+++ b/src/EvoCodeGen/EvoCodeGen/source.extension.vsixmanifest
@@ -9,7 +9,7 @@ Your template should have ".sbn" and language supported is Scriban.Evo Code </De
         <Tags>code generator, code generation, code template, code templating, generator, templates, scriban, textrude</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0]">
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 18.0)">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
     </Installation>
@@ -17,7 +17,7 @@ Your template should have ".sbn" and language supported is Scriban.Evo Code </De
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0]" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,18.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />


### PR DESCRIPTION
## Summary
- allow installation on Visual Studio 2022 by extending supported version range
- use `$(VSToolsPath)` in project references so the build can resolve text templating assemblies across VS versions

## Testing
- `dotnet test src/EvoCodeGen/EvoCodeGen.sln` *(fails: Microsoft.VsSDK.targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880fbfcc2c4833396836af26d7db386